### PR TITLE
Minimal netstandard 2.0 compatibility.

### DIFF
--- a/src/cityjson.csproj
+++ b/src/cityjson.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>bertt.CityJSON</PackageId>
     <Authors>Bert Temme</Authors>
     <Company>Bert Temme</Company>
@@ -17,10 +17,11 @@
     <PackageReleaseNotes>initial release</PackageReleaseNotes>
 	<PackageVersion>2.4</PackageVersion>
 	<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NetTopologySuite" Version="2.6.0" />
+    <PackageReference Include="NetTopologySuite" Version="2.6.0.0" />
     <PackageReference Include="NetTopologySuite.Features" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -8,6 +8,7 @@
     <AssemblyName>cityjson.tests</AssemblyName>
 
     <RootNamespace>CityJSON.Tests</RootNamespace>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Here's a cleaned up/minimal pull request for netstandard 2.0.

-  I've commented out net48 tests, but they do run ok on this side.
- The LangVersion is required by rider on windows, is that ok to leave?

This replaces #9